### PR TITLE
Support batch image processing

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,12 +5,14 @@
   const widthValue = document.getElementById("widthValue");
   const heightValue = document.getElementById("heightValue");
   const processButton = document.getElementById("processButton");
-  const originalPreview = document.getElementById("originalPreview");
-  const resultPreview = document.getElementById("resultPreview");
-  const downloadLink = document.getElementById("downloadLink");
   const modelStatus = document.getElementById("modelStatus");
+  const gallery = document.getElementById("gallery");
+  const galleryStatus = document.getElementById("galleryStatus");
+  const batchProgress = document.getElementById("batchProgress");
   const canvas = document.getElementById("workCanvas");
   const ctx = canvas.getContext("2d", { willReadFrequently: true });
+
+  const defaultProcessLabel = processButton.textContent;
 
   const MODEL_PATH = "models/lama-inpaint-512.onnx";
   const ORT_BASE_PATH = "libs/onnxruntime-web";
@@ -25,7 +27,8 @@
     error: null,
   };
 
-  let loadedImage = null;
+  let jobs = [];
+  let jobCounter = 0;
   let isProcessing = false;
   let pendingAutoUpdate = false;
   let modelLoadingPromise = null;
@@ -60,6 +63,22 @@
     }
   }
 
+  function setGalleryStatus(message) {
+    if (galleryStatus) {
+      galleryStatus.textContent = message;
+    }
+  }
+
+  function setBatchProgress(message) {
+    if (batchProgress) {
+      batchProgress.textContent = message;
+    }
+  }
+
+  function resetBatchProgress() {
+    setBatchProgress("");
+  }
+
   function updateSliderLabels() {
     widthValue.textContent = widthSlider.value;
     heightValue.textContent = heightSlider.value;
@@ -73,56 +92,210 @@
     container.appendChild(img);
   }
 
-  function disableControls() {
-    processButton.disabled = true;
+  function setInteractiveState(isInteractive) {
+    input.disabled = !isInteractive;
+    widthSlider.disabled = !isInteractive;
+    heightSlider.disabled = !isInteractive;
+  }
+
+  function resetJobs() {
+    jobs.forEach((job) => {
+      if (job.image) {
+        job.image.src = "";
+      }
+    });
+
+    jobs = [];
+    jobCounter = 0;
+
+    if (gallery) {
+      gallery.innerHTML = "";
+    }
+
+    resetBatchProgress();
+    updateGalleryPreparationStatus();
+    updateProcessButtonState();
+  }
+
+  function createDownloadName(filename) {
+    if (!filename) {
+      return "cleaned-image.png";
+    }
+
+    const lastDot = filename.lastIndexOf(".");
+    const baseName = lastDot > 0 ? filename.slice(0, lastDot) : filename;
+    const safeBase = baseName.trim() || "cleaned-image";
+
+    return `${safeBase}-cleaned.png`;
+  }
+
+  function createJob(file) {
+    const job = {
+      id: `job-${Date.now()}-${jobCounter}`,
+      file,
+      status: "loading",
+      needsProcessing: false,
+      originalUrl: null,
+      cleanedUrl: null,
+      image: null,
+      elements: null,
+    };
+
+    jobCounter += 1;
+    return job;
+  }
+
+  function createJobCard(job) {
+    if (!gallery) {
+      return;
+    }
+
+    const card = document.createElement("article");
+    card.className = "card preview-card";
+    card.setAttribute("role", "listitem");
+
+    const heading = document.createElement("h3");
+    heading.textContent = job.file.name;
+
+    const previewPair = document.createElement("div");
+    previewPair.className = "preview-pair";
+
+    const originalWrapper = document.createElement("div");
+    originalWrapper.className = "preview";
+    setPlaceholder(originalWrapper, "Loading original preview…");
+
+    const resultWrapper = document.createElement("div");
+    resultWrapper.className = "preview";
+    setPlaceholder(
+      resultWrapper,
+      modelState.ready
+        ? "After processing, the cleaned image will appear here."
+        : "The AI model is still preparing. Processing will start once it's ready."
+    );
+
+    previewPair.append(originalWrapper, resultWrapper);
+
+    const statusText = document.createElement("p");
+    statusText.className = "preview-status";
+    statusText.textContent = "Loading image…";
+
+    const downloadLink = document.createElement("a");
+    downloadLink.className = "download";
+    downloadLink.download = createDownloadName(job.file.name);
+    downloadLink.textContent = "Download cleaned image";
     downloadLink.classList.remove("is-active");
     downloadLink.removeAttribute("href");
+
+    card.append(heading, previewPair, statusText, downloadLink);
+    gallery.appendChild(card);
+
+    job.elements = {
+      card,
+      originalWrapper,
+      resultWrapper,
+      statusText,
+      downloadLink,
+    };
+  }
+
+  function updateGalleryPreparationStatus() {
+    if (!jobs.length) {
+      setGalleryStatus(
+        "Choose one or more images to begin removing the upper-right text."
+      );
+      return;
+    }
+
+    const readyCount = jobs.filter(
+      (job) => job.image && job.status !== "error"
+    ).length;
+
+    if (readyCount === 0) {
+      setGalleryStatus(
+        `Preparing ${jobs.length} image${jobs.length === 1 ? "" : "s"} for cleanup…`
+      );
+    } else if (readyCount < jobs.length) {
+      setGalleryStatus(
+        `${readyCount} of ${jobs.length} image${jobs.length === 1 ? "" : "s"} ready for processing.`
+      );
+    } else {
+      setGalleryStatus(
+        `${jobs.length} image${jobs.length === 1 ? " is" : "s are"} ready. Use “Remove text” to run the cleanup.`
+      );
+    }
+  }
+
+  function loadJob(job) {
+    const reader = new FileReader();
+
+    reader.onload = (event) => {
+      const dataUrl = event.target.result;
+      job.originalUrl = dataUrl;
+
+      if (job.elements) {
+        displayImage(
+          job.elements.originalWrapper,
+          dataUrl,
+          `Original preview for ${job.file.name}`
+        );
+      }
+
+      const image = new Image();
+      image.onload = () => {
+        job.image = image;
+        job.status = "ready";
+        job.needsProcessing = true;
+        if (job.elements) {
+          job.elements.statusText.textContent =
+            "Ready for processing. Use the Remove text button to begin.";
+        }
+        updateGalleryPreparationStatus();
+        updateProcessButtonState();
+      };
+      image.onerror = () => {
+        job.image = null;
+        job.status = "error";
+        job.needsProcessing = false;
+        if (job.elements) {
+          setPlaceholder(
+            job.elements.originalWrapper,
+            "We couldn't load that image. Please try another file."
+          );
+          job.elements.statusText.textContent =
+            "We couldn't load that image. Please try another file.";
+        }
+        updateGalleryPreparationStatus();
+        updateProcessButtonState();
+      };
+      image.src = dataUrl;
+    };
+
+    reader.onerror = () => {
+      job.image = null;
+      job.status = "error";
+      job.needsProcessing = false;
+      if (job.elements) {
+        setPlaceholder(
+          job.elements.originalWrapper,
+          "There was a problem reading the file. Please try again."
+        );
+        job.elements.statusText.textContent =
+          "There was a problem reading the file. Please try again.";
+      }
+      updateGalleryPreparationStatus();
+      updateProcessButtonState();
+    };
+
+    reader.readAsDataURL(job.file);
   }
 
   function updateProcessButtonState() {
-    const canProcess = Boolean(loadedImage) && modelState.ready && !isProcessing;
-    processButton.disabled = !canProcess;
-  }
+    const hasProcessableJob = jobs.some(
+      (job) => job.image && job.needsProcessing
+    );
 
-  function loadFromFile(file) {
-    const reader = new FileReader();
-    reader.onload = (event) => {
-      const img = new Image();
-      img.onload = () => {
-        loadedImage = img;
-        displayImage(
-          originalPreview,
-          img.src,
-          "Uploaded image preview ready for processing"
-        );
-        setPlaceholder(
-          resultPreview,
-          modelState.ready
-            ? "After processing, the cleaned image will appear here."
-            : "The AI model is still preparing. Processing will start once it's ready."
-        );
-        updateProcessButtonState();
-      };
-      img.onerror = () => {
-        loadedImage = null;
-        setPlaceholder(
-          originalPreview,
-          "We couldn't load that image. Please try another file."
-        );
-        disableControls();
-        updateProcessButtonState();
-      };
-      img.src = event.target.result;
-    };
-    reader.onerror = () => {
-      setPlaceholder(
-        originalPreview,
-        "There was a problem reading the file. Please try again."
-      );
-      disableControls();
-      updateProcessButtonState();
-    };
-    reader.readAsDataURL(file);
+    processButton.disabled =
+      !modelState.ready || !hasProcessableJob || isProcessing;
   }
 
   function normalizePixel(value) {
@@ -302,159 +475,246 @@
     await modelLoadingPromise;
   }
 
-  async function removeUpperRightText() {
-    if (!loadedImage) {
-      pendingAutoUpdate = false;
-      return;
-    }
+  function getProcessableJobs() {
+    return jobs.filter((job) => job.image && job.needsProcessing);
+  }
 
-    if (isProcessing) {
-      pendingAutoUpdate = true;
-      return;
-    }
-
-    if (!modelState.ready) {
-      await ensureModelReady();
-      if (!modelState.ready) {
-        pendingAutoUpdate = false;
-        setPlaceholder(
-          resultPreview,
-          "The AI model is not ready. Check the setup instructions to continue."
-        );
-        return;
-      }
-    }
-
-    isProcessing = true;
-    updateProcessButtonState();
-    setPlaceholder(resultPreview, "Running the inpainting model…");
-    downloadLink.classList.remove("is-active");
-    downloadLink.removeAttribute("href");
-
+  async function runInpainting(job) {
     const widthPercent = Number(widthSlider.value) / 100;
     const heightPercent = Number(heightSlider.value) / 100;
 
-    const imgWidth = loadedImage.naturalWidth || loadedImage.width;
-    const imgHeight = loadedImage.naturalHeight || loadedImage.height;
+    const imgWidth = job.image.naturalWidth || job.image.width;
+    const imgHeight = job.image.naturalHeight || job.image.height;
     const regionWidth = Math.round(imgWidth * widthPercent);
     const regionHeight = Math.round(imgHeight * heightPercent);
 
     canvas.width = imgWidth;
     canvas.height = imgHeight;
-    ctx.drawImage(loadedImage, 0, 0);
+    ctx.drawImage(job.image, 0, 0);
 
     const startX = Math.max(imgWidth - regionWidth, 0);
     const imageData = ctx.getImageData(0, 0, imgWidth, imgHeight);
 
+    const { imageTensorData, maskTensorData, maskBinary } = prepareInpaintingInputs(
+      imageData,
+      imgWidth,
+      imgHeight,
+      startX,
+      regionHeight
+    );
+
+    const feeds = {
+      [modelState.imageInputName]: new ort.Tensor(
+        "float32",
+        imageTensorData,
+        [1, 3, imgHeight, imgWidth]
+      ),
+      [modelState.maskInputName]: new ort.Tensor(
+        "float32",
+        maskTensorData,
+        [1, 1, imgHeight, imgWidth]
+      ),
+    };
+
+    const output = await modelState.session.run(feeds);
+    const outputTensor = output[modelState.outputName];
+
+    if (!outputTensor) {
+      throw new Error("Model inference returned an empty result.");
+    }
+
+    if (
+      outputTensor.dims[2] !== imgHeight ||
+      outputTensor.dims[3] !== imgWidth
+    ) {
+      throw new Error(
+        `Model output size mismatch. Expected ${imgWidth}x${imgHeight}, got ${outputTensor.dims[3]}x${outputTensor.dims[2]}.`
+      );
+    }
+
+    const updatedPixels = compositeInpaintedPixels(
+      imageData.data,
+      outputTensor.data,
+      maskBinary,
+      imgWidth,
+      imgHeight
+    );
+
+    const updatedImageData = new ImageData(updatedPixels, imgWidth, imgHeight);
+    ctx.putImageData(updatedImageData, 0, 0);
+
+    return canvas.toDataURL("image/png");
+  }
+
+  async function processJobs() {
+    const jobsToProcess = getProcessableJobs();
+    if (!jobsToProcess.length) {
+      return;
+    }
+
+    if (!modelState.ready) {
+      await ensureModelReady();
+    }
+
+    if (!modelState.ready) {
+      setBatchProgress(
+        "The AI model is not ready. Check the setup instructions to continue."
+      );
+      jobsToProcess.forEach((job) => {
+        if (job.elements) {
+          job.elements.statusText.textContent =
+            "The AI model is not ready. Check the setup instructions to continue.";
+        }
+      });
+      updateProcessButtonState();
+      return;
+    }
+
+    isProcessing = true;
+    setInteractiveState(false);
+    processButton.textContent = "Processing…";
+    updateProcessButtonState();
+
     try {
-      const { imageTensorData, maskTensorData, maskBinary } = prepareInpaintingInputs(
-        imageData,
-        imgWidth,
-        imgHeight,
-        startX,
-        regionHeight
+      setBatchProgress(
+        `Processing ${jobsToProcess.length} image${
+          jobsToProcess.length === 1 ? "" : "s"
+        }…`
+      );
+      setGalleryStatus(
+        `Running AI cleanup for ${jobsToProcess.length} image${
+          jobsToProcess.length === 1 ? "" : "s"
+        }…`
       );
 
-      const feeds = {
-        [modelState.imageInputName]: new ort.Tensor(
-          "float32",
-          imageTensorData,
-          [1, 3, imgHeight, imgWidth]
-        ),
-        [modelState.maskInputName]: new ort.Tensor(
-          "float32",
-          maskTensorData,
-          [1, 1, imgHeight, imgWidth]
-        ),
-      };
-
-      const output = await modelState.session.run(feeds);
-      const outputTensor = output[modelState.outputName];
-
-      if (!outputTensor) {
-        throw new Error("Model inference returned an empty result.");
-      }
-
-      if (
-        outputTensor.dims[2] !== imgHeight ||
-        outputTensor.dims[3] !== imgWidth
-      ) {
-        throw new Error(
-          `Model output size mismatch. Expected ${imgWidth}x${imgHeight}, got ${outputTensor.dims[3]}x${outputTensor.dims[2]}.`
+      for (let index = 0; index < jobsToProcess.length; index += 1) {
+        const job = jobsToProcess[index];
+        job.status = "processing";
+        setBatchProgress(
+          `Processing image ${index + 1} of ${jobsToProcess.length}…`
         );
+
+        if (job.elements) {
+          setPlaceholder(
+            job.elements.resultWrapper,
+            "Running the inpainting model…"
+          );
+          job.elements.downloadLink.classList.remove("is-active");
+          job.elements.downloadLink.removeAttribute("href");
+          job.elements.statusText.textContent = "Running the inpainting model…";
+        }
+
+        try {
+          const cleanedUrl = await runInpainting(job);
+          job.cleanedUrl = cleanedUrl;
+          job.needsProcessing = pendingAutoUpdate;
+          job.status = "complete";
+
+          if (job.elements) {
+            displayImage(
+              job.elements.resultWrapper,
+              cleanedUrl,
+              `Image ${job.file.name} with upper-right text removed`
+            );
+            job.elements.downloadLink.href = cleanedUrl;
+            job.elements.downloadLink.classList.add("is-active");
+            job.elements.statusText.textContent = "Cleanup complete.";
+          }
+        } catch (error) {
+          console.error("Inpainting failed", error);
+          job.needsProcessing = pendingAutoUpdate;
+          job.status = "error";
+
+          if (job.elements) {
+            setPlaceholder(
+              job.elements.resultWrapper,
+              "We couldn't run the AI cleanup. Confirm the model assets are installed."
+            );
+            job.elements.statusText.textContent =
+              "We couldn't run the AI cleanup. Confirm the model assets are installed.";
+          }
+        }
       }
 
-      const updatedPixels = compositeInpaintedPixels(
-        imageData.data,
-        outputTensor.data,
-        maskBinary,
-        imgWidth,
-        imgHeight
-      );
-
-      const updatedImageData = new ImageData(updatedPixels, imgWidth, imgHeight);
-      ctx.putImageData(updatedImageData, 0, 0);
-
-      const cleanedUrl = canvas.toDataURL("image/png");
-      displayImage(resultPreview, cleanedUrl, "Image with upper-right text removed");
-      downloadLink.href = cleanedUrl;
-      downloadLink.classList.add("is-active");
-    } catch (error) {
-      console.error("Inpainting failed", error);
-      setPlaceholder(
-        resultPreview,
-        "We couldn't run the AI cleanup. Confirm the model assets are installed."
+      setBatchProgress("Processing complete.");
+      setGalleryStatus(
+        "Batch processing finished. Adjust the sliders or add more images to continue."
       );
     } finally {
       isProcessing = false;
+      setInteractiveState(true);
+      processButton.textContent = defaultProcessLabel;
       updateProcessButtonState();
 
       if (pendingAutoUpdate) {
         pendingAutoUpdate = false;
-        removeUpperRightText();
+        processJobs();
       }
     }
   }
 
   input.addEventListener("change", (event) => {
-    const file = event.target.files && event.target.files[0];
-    if (!file) {
-      loadedImage = null;
-      setPlaceholder(
-        originalPreview,
-        "Choose an image to begin removing the upper-right text."
-      );
-      disableControls();
+    const files = Array.from(event.target.files || []);
+
+    resetJobs();
+
+    if (!files.length) {
+      updateGalleryPreparationStatus();
       return;
     }
 
-    disableControls();
+    setGalleryStatus(
+      `Preparing ${files.length} image${files.length === 1 ? "" : "s"} for cleanup…`
+    );
+
+    files.forEach((file) => {
+      const job = createJob(file);
+      jobs.push(job);
+      createJobCard(job);
+      loadJob(job);
+    });
+
     updateProcessButtonState();
-    loadFromFile(file);
   });
 
   processButton.addEventListener("click", () => {
-    removeUpperRightText();
-  });
-  widthSlider.addEventListener("input", () => {
-    updateSliderLabels();
-    pendingAutoUpdate = true;
-    removeUpperRightText();
-  });
-  heightSlider.addEventListener("input", () => {
-    updateSliderLabels();
-    pendingAutoUpdate = true;
-    removeUpperRightText();
+    processJobs();
   });
 
+  function handleSliderChange() {
+    updateSliderLabels();
+
+    const hasEligibleJobs = jobs.some((job) => job.image);
+    if (!hasEligibleJobs) {
+      return;
+    }
+
+    jobs.forEach((job) => {
+      if (job.image) {
+        job.needsProcessing = true;
+      }
+    });
+
+    updateProcessButtonState();
+    setGalleryStatus(
+      "Removal area updated. The batch will be processed with the new settings."
+    );
+
+    if (isProcessing) {
+      pendingAutoUpdate = true;
+      setBatchProgress(
+        "Settings updated. Reprocessing will begin after the current batch."
+      );
+      return;
+    }
+
+    processJobs();
+  }
+
+  widthSlider.addEventListener("input", handleSliderChange);
+  heightSlider.addEventListener("input", handleSliderChange);
+
   updateSliderLabels();
-  setPlaceholder(
-    originalPreview,
-    "Choose an image to begin removing the upper-right text."
-  );
-  setPlaceholder(
-    resultPreview,
-    "After processing, the cleaned image will appear here."
-  );
+  updateGalleryPreparationStatus();
   ensureModelReady();
 })();

--- a/index.html
+++ b/index.html
@@ -22,8 +22,17 @@
 
       <section class="controls card">
         <div class="control-group">
-          <label for="imageInput" class="control-label">Select an image</label>
-          <input type="file" id="imageInput" accept="image/*" />
+          <label for="imageInput" class="control-label">Select images to clean</label>
+          <input
+            type="file"
+            id="imageInput"
+            accept="image/*"
+            multiple
+            aria-describedby="imageInputDescription"
+          />
+          <p id="imageInputDescription" class="control-help">
+            Choose one or more image files to process together.
+          </p>
         </div>
 
         <div class="sliders" aria-live="polite">
@@ -57,24 +66,29 @@
       </section>
 
       <section class="previews">
-        <article class="card">
-          <h2>Original</h2>
-          <div class="preview" id="originalPreview">
-            <p class="placeholder">Your uploaded image will appear here.</p>
-          </div>
+        <article class="card gallery-info">
+          <h2>Selected images</h2>
+          <p
+            id="galleryStatus"
+            class="gallery-status"
+            aria-live="polite"
+          >
+            Choose one or more images to begin removing the upper-right text.
+          </p>
+          <p
+            id="batchProgress"
+            class="gallery-progress"
+            role="status"
+            aria-live="polite"
+          ></p>
         </article>
 
-        <article class="card">
-          <h2>Result</h2>
-          <div class="preview" id="resultPreview">
-            <p class="placeholder">
-              After processing, the cleaned image will appear here.
-            </p>
-          </div>
-          <a id="downloadLink" class="download" download="cleaned-image.png"
-            >Download cleaned image</a
-          >
-        </article>
+        <div
+          id="gallery"
+          class="gallery-grid"
+          role="list"
+          aria-live="polite"
+        ></div>
       </section>
     </main>
 

--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,12 @@ body {
   font-weight: 600;
 }
 
+.control-help {
+  margin: -0.25rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.9);
+}
+
 input[type="file"] {
   padding: 0.65rem;
   border-radius: 0.75rem;
@@ -132,9 +138,49 @@ button#processButton:not(:disabled):hover {
 }
 
 .previews {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.gallery-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.gallery-status {
+  margin: 0;
+  color: rgba(71, 85, 105, 0.9);
+}
+
+.gallery-progress {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(51, 65, 85, 0.95);
+}
+
+.gallery-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
+}
+
+.preview-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.preview-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.preview-pair {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
 }
 
 .preview {
@@ -181,6 +227,12 @@ button#processButton:not(:disabled):hover {
 
 .download.is-active {
   visibility: visible;
+}
+
+.preview-status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(71, 85, 105, 0.9);
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- allow selecting multiple images at once with updated guidance for batch uploads
- add a gallery layout with per-image cards, previews, progress updates, and download links
- queue each selected image through the inpainting pipeline while disabling controls during processing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd9b356f48323bb44ca52bf09cb4d